### PR TITLE
tell the parser subclass where/how to load in the pcpp.lextab module

### DIFF
--- a/bos2cob_py3.py
+++ b/bos2cob_py3.py
@@ -1450,10 +1450,14 @@ def preprocess(code, include_path, defs = {"TRUE" : "1", "FALSE" : "0", "UNKNOWN
 
 if not args.nopcpp:
 	from io import StringIO
+	from pcpp import lextab
+	from pcpp.ply.ply import lex
+
 
 	# Custom Preprocessor class inheriting from pcpp.Preprocessor
 	class MyPreprocessor(pcpp.Preprocessor):
 		def __init__(self, input_string):
+			self.lexer = lex.lex(object=pcpp.parser, lextab=lextab, optimize=True)
 			super(MyPreprocessor, self).__init__()
 			# Use StringIO to simulate file input and output
 			self.line_directive = None

--- a/bos_preprocessor.py
+++ b/bos_preprocessor.py
@@ -6,6 +6,9 @@ import os
 import importlib
 import sys
 
+from pcpp import lextab
+from pcpp.ply.ply import lex
+
 LINEAR_CONSTANT = 65536.000000
 ANGULAR_CONSTANT = 182.00000
 
@@ -18,6 +21,7 @@ from io import StringIO
 # Custom Preprocessor class inheriting from pcpp.Preprocessor
 class MyPreprocessor(pcpp.Preprocessor):
     def __init__(self, input_string):
+        self.lexer = lex.lex(object=pcpp.parser, lextab=lextab, optimize=True)
         super(MyPreprocessor, self).__init__()
         # Use StringIO to simulate file input and output
         self.input = input_string


### PR DESCRIPTION
fixes
`WARNING: Couldn't write lextab module 'pcpp.lextab'. [Errno 2] No such file or directory `

by having the Preprocessor subclass use a `ply.lexer` instance that knows where the existing pcpp.lextab file is
