### PR TITLE
Make decompiler accept directory as an argument and accept a file too.

### DIFF
--- a/cob_decompiler.py
+++ b/cob_decompiler.py
@@ -168,17 +168,19 @@ def decompile(fname):
 	#print(decomp)
 	return decomp
 
+
 def get_filenames():
 	if len(sys.argv) > 1:
 		path = sys.argv[1]
-		if os.path.isdir(path):
-			filenames = os.listdir(path)
-		else:
-			filenames = [path]
 	else:
 		path = os.getcwd()
+
+	if os.path.isdir(path):
 		filenames = os.listdir(path)
+	else:
+		filenames = [path]
 	return path, filenames
+
 
 if __name__ == "__main__":
 	path, filenames = get_filenames()

--- a/cob_decompiler.py
+++ b/cob_decompiler.py
@@ -167,7 +167,8 @@ def decompile(fname):
 				cmd += str(op)
 	#print(decomp)
 	return decomp
-if __name__ == "__main__":
+
+def get_filenames():
 	if len(sys.argv) > 1:
 		path = sys.argv[1]
 		if os.path.isdir(path):
@@ -177,6 +178,10 @@ if __name__ == "__main__":
 	else:
 		path = os.getcwd()
 		filenames = os.listdir(path)
+	return path, filenames
+
+if __name__ == "__main__":
+	path, filenames = get_filenames()
 	ipairs = {}
 	for filename in filenames:
 		if filename.lower().endswith(".cob"):	

--- a/cob_decompiler.py
+++ b/cob_decompiler.py
@@ -1,7 +1,8 @@
 #import bos2cob_py3
 import cob_file
 import struct
-import os 
+import os
+import sys
 
 pf = cob_file.PACK_FORMAT
 hf = cob_file.COB_HEADER_FIELDS
@@ -88,14 +89,13 @@ for k,v in OPCODES.items():
 	rop[v] = k
 
 defines = {}
-for line in open('recoil_common_includes.h','r').readlines():
-	if '#define ' in line:
-		line = line.partition('#define ')[2].split(None, 1)
-		print (line)
-		if (len(line) > 1):
-			defines[line[0]] = line[1]
-
-
+if os.path.exists('recoil_common_includes.h'):
+	for line in open('recoil_common_includes.h','r').readlines():
+		if '#define ' in line:
+			line = line.partition('#define ')[2].split(None, 1)
+			print (line)
+			if (len(line) > 1):
+				defines[line[0]] = line[1]
 
 def get_name(cob, pos):
 	start = pos
@@ -168,9 +168,17 @@ def decompile(fname):
 	#print(decomp)
 	return decomp
 if __name__ == "__main__":
-	path = os.getcwd()
+	if len(sys.argv) > 1:
+		path = sys.argv[1]
+		if os.path.isdir(path):
+			filenames = os.listdir(path)
+		else:
+			filenames = [path]
+	else:
+		path = os.getcwd()
+		filenames = os.listdir(path)
 	ipairs = {}
-	for filename in os.listdir(path):
+	for filename in filenames:
 		if filename.lower().endswith(".cob"):	
 			print (path+filename)
 			res = decompile(os.path.join(path ,filename))	

--- a/cob_decompiler.py
+++ b/cob_decompiler.py
@@ -169,21 +169,23 @@ def decompile(fname):
 	return decomp
 
 
-def get_filenames():
+def get_path():
 	if len(sys.argv) > 1:
 		path = sys.argv[1]
 	else:
 		path = os.getcwd()
+	return path
 
+def get_filenames(path):
 	if os.path.isdir(path):
 		filenames = os.listdir(path)
 	else:
 		filenames = [path]
-	return path, filenames
-
+	return filenames
 
 if __name__ == "__main__":
-	path, filenames = get_filenames()
+	path = get_path()
+	filenames = get_filenames(path)
 	ipairs = {}
 	for filename in filenames:
 		if filename.lower().endswith(".cob"):	


### PR DESCRIPTION
### Work done

- Make decompiler accept directory as an argument and accept a file too.
  - it would expect to work on `current dir` only.
- Also fix problem when recoil headers don't exist (they're not needed but would crash if not found).